### PR TITLE
Add a poem word element so we can render individual poem words directly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ minecraft {
 }
 
 dependencies {
-    compileOnly "gigaherz.guidebook:Guidebook-1.12.2:2.6.0"
+    compileOnly "gigaherz.guidebook:Guidebook-1.12.2:2.6.5"
     compileOnly "com.xcompwiz.mystcraft:mystcraft:0.13.6.00"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,10 @@ repositories {
     maven {
         url "http://dogforce-games.com/maven"
     }
+    maven {
+        name "xcompwiz"
+        url "http://maven.xcompwiz.com"
+    }
 }
 
 apply plugin: 'net.minecraftforge.gradle.forge'
@@ -41,7 +45,8 @@ minecraft {
 }
 
 dependencies {
-    deobfCompile "gigaherz.guidebook:Guidebook-1.12.2:2.6.0"
+    compileOnly "gigaherz.guidebook:Guidebook-1.12.2:2.6.0"
+    compileOnly "com.xcompwiz.mystcraft:mystcraft:0.13.6.00"
 }
 
 processResources {

--- a/src/main/java/thefloydman/ltta/LTTA.java
+++ b/src/main/java/thefloydman/ltta/LTTA.java
@@ -3,6 +3,7 @@ package thefloydman.ltta;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -18,6 +19,7 @@ import net.minecraft.util.ResourceLocation;
 import gigaherz.guidebook.client.BookRegistryEvent;
 
 import thefloydman.ltta.config.ModConfig;
+import thefloydman.ltta.proxy.CommonProxy;
 
 @Mod(modid = LTTA.MOD_ID, name = LTTA.NAME, version = LTTA.VERSION, dependencies = "after:gbook;after:mystcraft")
 @Mod.EventBusSubscriber
@@ -26,7 +28,14 @@ public class LTTA {
 	public static final String MOD_ID = "ltta";
     public static final String NAME = "Linking Through the Ages";
     public static final String VERSION = "1.2.2";
-    
+
+    @SidedProxy(
+        clientSide = "thefloydman.ltta.proxy.ClientProxy",
+        serverSide = "thefloydman.ltta.proxy.CommonProxy"
+    )
+    public static CommonProxy proxy;
+
+
 	@Optional.Method(modid = "gbook")
     @SubscribeEvent
     public static void registerBook (BookRegistryEvent event) {
@@ -56,6 +65,8 @@ public class LTTA {
     public void preInit(FMLPreInitializationEvent event) {}
 
     @EventHandler
-    public void init(FMLInitializationEvent event) {}    
+    public void init(FMLInitializationEvent event) {
+        proxy.init(event);
+    }
     
 }

--- a/src/main/java/thefloydman/ltta/elements/MystPoemElement.java
+++ b/src/main/java/thefloydman/ltta/elements/MystPoemElement.java
@@ -1,0 +1,35 @@
+package thefloydman.ltta.elements;
+
+import gigaherz.guidebook.guidebook.IBookGraphics;
+import gigaherz.guidebook.guidebook.drawing.Size;
+import gigaherz.guidebook.guidebook.drawing.VisualElement;
+import thefloydman.ltta.LTTA;
+
+public class MystPoemElement extends VisualElement {
+    public String word;
+    public int poemX;
+    public int poemY;
+    public int poemSize;
+
+    public MystPoemElement(
+        Size size,
+        int positionMode,
+        float baseline,
+        int verticalAlign,
+        String word,
+        int poemX,
+        int poemY,
+        int poemSize
+    ) {
+        super(size, positionMode, baseline, verticalAlign);
+        this.word = word;
+        this.poemX = poemX;
+        this.poemY = poemY;
+        this.poemSize = poemSize;
+    }
+
+    @Override
+    public void draw(IBookGraphics nav) {
+        LTTA.proxy.drawPoemWord(poemX, poemY, 0, poemSize, word);
+    }
+}

--- a/src/main/java/thefloydman/ltta/proxy/ClientProxy.java
+++ b/src/main/java/thefloydman/ltta/proxy/ClientProxy.java
@@ -1,0 +1,32 @@
+package thefloydman.ltta.proxy;
+
+import com.xcompwiz.mystcraft.api.MystObjects;
+import com.xcompwiz.mystcraft.api.exception.APIUndefined;
+import com.xcompwiz.mystcraft.api.exception.APIVersionRemoved;
+import com.xcompwiz.mystcraft.api.exception.APIVersionUndefined;
+import com.xcompwiz.mystcraft.api.hook.RenderAPI;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+
+@Mod.EventBusSubscriber
+public class ClientProxy extends CommonProxy{
+    private RenderAPI renderApi;
+
+    @Override
+    public void init(FMLInitializationEvent event) {
+        super.init(event);
+
+        try {
+            renderApi = (RenderAPI)MystObjects.entryPoint.getProviderInstance().getAPIInstance("render-1");
+            // TODO: Log caught errors
+        } catch(APIVersionRemoved e1) {
+        } catch(APIVersionUndefined e2) {
+        } catch(APIUndefined e3) {
+        }
+    }
+
+    @Override
+    public void drawPoemWord(float x, float y, float z, float scale, String word) {
+        renderApi.drawWord(x, y, z, scale, word);
+    }
+}

--- a/src/main/java/thefloydman/ltta/proxy/CommonProxy.java
+++ b/src/main/java/thefloydman/ltta/proxy/CommonProxy.java
@@ -1,0 +1,12 @@
+package thefloydman.ltta.proxy;
+
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+
+
+@Mod.EventBusSubscriber
+public class CommonProxy {
+    public void init(FMLInitializationEvent event) {}
+
+    public void drawPoemWord(float x, float y, float z, float scale, String word) {}
+}


### PR DESCRIPTION
The next step is to create an element and register that element with Guidebook, but Guidebook is not set up to allow external registrations, so this PR is pending another PR to be created there.

Specifically the elements are parsed by name in [an if/else block here][0]. the pull request would add a String->(Element? ElementParser?) mapping with a public registration method to allow us to register additional elements.

[0]: https://github.com/gigaherz/Guidebook/blob/master/src/main/java/gigaherz/guidebook/guidebook/BookDocument.java#L581